### PR TITLE
Clarify "Christmas" to "Christmas until Epiphany", etc.

### DIFF
--- a/office-tex/chants/hy--iesu_nostra_redemptio.english.gabc
+++ b/office-tex/chants/hy--iesu_nostra_redemptio.english.gabc
@@ -27,7 +27,7 @@ That(g) see(gh)ing(g) you(fvED) we(f) may(e!fg) be(fe) blest.(e) (::)
 
 (Z)
 
-5. {Cre}<alt>Easter</alt>(f)a(ef!gh)tor(g) great,(fvED) be(f) you(e!fg) our(fe) guide(e) (;)
+5. {Cre}<alt>Easter until Ascension</alt>(f)a(ef!gh)tor(g) great,(fvED) be(f) you(e!fg) our(fe) guide(e) (;)
 In(g) this(hj) the(h) joy(gf) of(g) East(g)er-(f)tide;(ed) (:)
 When(c) e'er(d) as(d)saults(d) of(fe) death(de) im(e)pend,(e) (;)
 Your(g) peo(gh)ple(g) strength(fvED )en(f) and(e!fg) de(fe)fend.(e) (::)
@@ -41,7 +41,7 @@ A(efe)men.(de) (::)
 
 (Z-)
 
-5. {Be}<alt>Ascension</alt>(f) you(ef!gh) our(g) joy,(fvED) and(f) you(e!fg) our(fe) Lord,(e) (;)
+5. {Be}<alt>Ascension until Pentecost</alt>(f) you(ef!gh) our(g) joy,(fvED) and(f) you(e!fg) our(fe) Lord,(e) (;)
 Who(g) are(hj) to(h) be(gf) our(g) great(g) re(f)ward;(ed) (:)
 O(c) let(d) our(d) glo(d)ry(fe) be(de) in(e) you,(e) (;)
 For(g) e(gh)ver(g) and(fvED) for(f) e(e!fg)ver(fe) true.(e) (::)
@@ -65,4 +65,5 @@ To(g) Coun(hj)sel(h)lor(gf) let(g) praise(g) be(f) done;(ed) (:)
 And(c) may(d) the(d) Son(d) on(fe) us(de) be(e)low(e) (;)
 The(g) Ho(gh)ly(g) Spi(fvED)rit's(f) gift(e!fg) be(fe)stow.(e) (::)
 A(efe)men.(de) (::)
+
 %

--- a/office-tex/chants/hy--te_lucis--christmas.english.gabc
+++ b/office-tex/chants/hy--te_lucis--christmas.english.gabc
@@ -12,7 +12,7 @@ No(g) night(hj)ly(j) fears(ji) or(hg) fan(hi)ta(i)sies;(i) (:)
 Tread(h) un(h!jk)der(j)foot(ji) our(hg) ghost(h)ly(gf) foe,(ed!f!gh) (;)
 That(d) no(e) de(f)file(gh)ment(gf) we(g) may(fe) know.(e) (::)
 
-(Z) 3. <alt>Christmas</alt>{All}(d) glo(e)ry(f) be(gh) to(d) you,(e!fg) O(fe) Lord,(e) (;)
+(Z) 3. <alt>Christmas until Epiphany</alt>{All}(d) glo(e)ry(f) be(gh) to(d) you,(e!fg) O(fe) Lord,(e) (;)
 The(g) Vir(hj)gin's(j) Son,(ji) by(hg) all(hi) a(i)dored;(i) (:)
 With(h) Fa(h!jk)ther(j) and(ji) the(hg) Spi(h)rit(gf) be(ed!f!gh) (;)
 All(d) glo(e)ry(f) yours(gh) e(gf)ter(g)nal(fe)ly.(e) (::) A(efe)men.(de) (::) 

--- a/office-tex/chants/hy--te_lucis--christmas.gabc
+++ b/office-tex/chants/hy--te_lucis--christmas.gabc
@@ -11,7 +11,7 @@ Et(g) nóc(hj)ti(j)um(ji) phan(hg)tás(hi)ma(i)ta:(i) (:)
 Ho(h)stém(h!jk)que(j) no(ji)strum(hg) cóm(h)pri(gf)me,(ed!f!gh) (;)
 Ne(d) pol(e)lu(f)án(gh)tur(gf) cór(g)po(fe)ra.(e) (::)
 
-(Z) <alt>In Nativitate Domini</alt>3. Gló(d)ri(e)a(f) ti(gh)bi,(d) Dó(e!fg)mi(fe)ne,(e) (;)
+(Z) <alt>In Nativitate Domini usque ad Epiphaniam</alt>3. Gló(d)ri(e)a(f) ti(gh)bi,(d) Dó(e!fg)mi(fe)ne,(e) (;)
 Qui(g) na(hj)tus(j) es(ji) de(hg) Vír(hi)gi(i)ne,(i) (:)
 Cum(h) Pa(h!jk)tr<i>e</i> {e}t(j) Sanc(ji)to(hg) Spí(h)ri(gf)tu,(ed!f!gh) (;)
 In(d) sem(e)pi(f)tér(gh)na(gf) sǽ(g)cu(fe)la.(e) (::)

--- a/office-tex/varia/canticles--saturday.tex
+++ b/office-tex/varia/canticles--saturday.tex
@@ -1,4 +1,6 @@
-Christmas: \pageref{Ecce completa (Antiphona ad Nunc dimittis)} or \pageref{Alleluia Verbum caro (Antiphona ad Nunc dimittis)}.
+Christmas Eve: \pageref{Ecce completa (Antiphona ad Nunc dimittis)}.
+
+Christmas to Epiphany: \pageref{Alleluia Verbum caro (Antiphona ad Nunc dimittis)}.
 
 Epiphany: \pageref{Alleluia Omnes de Saba (Antiphona ad Nunc dimittis)}.
 
@@ -6,9 +8,9 @@ First and Second Weeks of Lent: \pageref{Evigila (Antiphona ad Nunc dimittis)}.
 
 Third Week of Lent until the Paschal Triduum: \pageref{O Rex (Antiphona ad Nunc dimittis)}.
 
-Easter: \pageref{Alleluia Resurrexit (Antiphona ad Nunc dimittis)}.
+Easter to Ascension: \pageref{Alleluia Resurrexit (Antiphona ad Nunc dimittis)}.
 
-Ascension: \pageref{Alleluia Ascendens (Antiphona ad Nunc dimittis)}.
+Ascension to Pentecost: \pageref{Alleluia Ascendens (Antiphona ad Nunc dimittis)}.
 
 Pentecost: \pageref{Alleluia Spiritus (Antiphona ad Nunc dimittis)}.
 

--- a/office-tex/varia/canticles--sunday.tex
+++ b/office-tex/varia/canticles--sunday.tex
@@ -6,9 +6,9 @@ First and Second Weeks of Lent: \pageref{Evigila (Antiphona ad Nunc dimittis)}.
 
 Third Week of Lent until the Paschal Triduum: \pageref{O Rex (Antiphona ad Nunc dimittis)}.
 
-Easter: \pageref{Alleluia Resurrexit (Antiphona ad Nunc dimittis)}.
+Easter to Ascension: \pageref{Alleluia Resurrexit (Antiphona ad Nunc dimittis)}.
 
-Ascension: \pageref{Alleluia Ascendens (Antiphona ad Nunc dimittis)}.
+Ascension to Pentecost: \pageref{Alleluia Ascendens (Antiphona ad Nunc dimittis)}.
 
 Pentecost: \pageref{Alleluia Spiritus (Antiphona ad Nunc dimittis)}.
 

--- a/office-tex/varia/canticles--weekdays.tex
+++ b/office-tex/varia/canticles--weekdays.tex
@@ -1,16 +1,12 @@
-Christmas: \pageref{Ecce completa (Antiphona ad Nunc dimittis)} or \pageref{Alleluia Verbum caro (Antiphona ad Nunc dimittis)}.
-
-Epiphany: \pageref{Alleluia Omnes de Saba (Antiphona ad Nunc dimittis)}.
+Christmas to Epiphany: \pageref{Alleluia Verbum caro (Antiphona ad Nunc dimittis)}.
 
 First and Second Weeks of Lent: \pageref{Evigila (Antiphona ad Nunc dimittis)}.
 
 Third Week of Lent until the Paschal Triduum: \pageref{O Rex (Antiphona ad Nunc dimittis)}.
 
-Easter: \pageref{Alleluia Resurrexit (Antiphona ad Nunc dimittis)}.
+Easter to Ascension: \pageref{Alleluia Resurrexit (Antiphona ad Nunc dimittis)}.
 
-Ascension: \pageref{Alleluia Ascendens (Antiphona ad Nunc dimittis)}.
-
-Pentecost: \pageref{Alleluia Spiritus (Antiphona ad Nunc dimittis)}.
+Ascension to Pentecost: \pageref{Alleluia Ascendens (Antiphona ad Nunc dimittis)}.
 
 \vspace{5pt}
 

--- a/office-tex/varia/hymns--m-f--english.tex
+++ b/office-tex/varia/hymns--m-f--english.tex
@@ -1,4 +1,4 @@
-Christmas to Epiphany: \pageref{To you before the close of day (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
+Christmas to Epiphany inclusive: \pageref{To you before the close of day (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
 
 Lent: \pageref{O Christ you are the light and day (Sundays and Weekdays in Lent)}.
 

--- a/office-tex/varia/hymns--m-f--latin.tex
+++ b/office-tex/varia/hymns--m-f--latin.tex
@@ -1,4 +1,4 @@
-Christmas to Epiphany: \pageref{Te lucis ante terminum (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
+Christmas to Epiphany inclusive: \pageref{Te lucis ante terminum (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
 
 Lent: \pageref{Christe qui lux es et dies (Sundays and Weekdays in Lent)}
 

--- a/office-tex/varia/hymns--saturday_and_sunday--english.tex
+++ b/office-tex/varia/hymns--saturday_and_sunday--english.tex
@@ -1,6 +1,6 @@
 Advent: \pageref{To you before the close of day (Sundays in Advent) (Sundays in Advent)}.
 
-Christmas to Epiphany: \pageref{To you before the close of day (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
+Christmas to Epiphany inclusive: \pageref{To you before the close of day (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
 
 Lent: \pageref{O Christ you are the light and day (Sundays and Weekdays in Lent)}.
 

--- a/office-tex/varia/hymns--saturday_and_sunday--latin.tex
+++ b/office-tex/varia/hymns--saturday_and_sunday--latin.tex
@@ -1,6 +1,6 @@
 Advent: \pageref{Te lucis ante terminum (Sundays in Advent) (Sundays in Advent)}.
 
-Christmas to Epiphany: \pageref{Te lucis ante terminum (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
+Christmas to Epiphany inclusive: \pageref{Te lucis ante terminum (Christmas to Epiphany) (Daily from Christmas to Epiphany)}.
 
 Lent: \pageref{Christe qui lux es et dies (Sundays and Weekdays in Lent)}
 

--- a/office-tex/varia/responsories--m-t-w.tex
+++ b/office-tex/varia/responsories--m-t-w.tex
@@ -1,4 +1,4 @@
-Christmas: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
+Christmas to Epiphany: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
 
 Weekdays in Lent: \pageref{In pace (Responsorium prolixa)}.
 

--- a/office-tex/varia/responsories--saturday.tex
+++ b/office-tex/varia/responsories--saturday.tex
@@ -1,6 +1,6 @@
 Solemnities in Ordinary Time: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
 
-Christmas: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
+Christmas to Epiphany inclusive: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
 
 Lent and Holy Week: \pageref{Media vita (Responsorium prolixa)}.
 

--- a/office-tex/varia/responsories--sunday.tex
+++ b/office-tex/varia/responsories--sunday.tex
@@ -1,6 +1,6 @@
 Solemnities in Ordinary Time: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
 
-Christmas: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
+Christmas to Epiphany inclusive: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
 
 Lent and Holy Week: \pageref{Media vita (Responsorium prolixa)}.
 

--- a/office-tex/varia/responsories--th-fr.tex
+++ b/office-tex/varia/responsories--th-fr.tex
@@ -1,4 +1,4 @@
-Christmas: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
+Christmas to Epiphany: \pageref{In manus tuas ... alleluia (Responsorium brevis)}.
 
 Weekdays in Lent: \pageref{In pace (Responsorium prolixa)}.
 


### PR DESCRIPTION
Some hymn verses were labeled "Christmas," "Easter", or "Ascension", and this clarifies that the verse is (I think?) used from that day onward.

Elsewhere in this project, "X until Y" seems to mean "from X to Y, including X but not including Y", so I kept this convention.