### PR TITLE
Pass `normalem` option to `ulem`

### DIFF
--- a/graduale-tex/000_header.tex
+++ b/graduale-tex/000_header.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/00_Ordo_Missae_OP.tex
+++ b/graduale-tex/00_Ordo_Missae_OP.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/10.misc_everything.tex
+++ b/graduale-tex/10.misc_everything.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/10_Easter--Vidi-aquam.tex
+++ b/graduale-tex/10_Easter--Vidi-aquam.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/10_Easter_Vigil_Triple_Alleluia.tex
+++ b/graduale-tex/10_Easter_Vigil_Triple_Alleluia.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/10_Good_Friday_Improperia.tex
+++ b/graduale-tex/10_Good_Friday_Improperia.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/10_St.Dominic.tex
+++ b/graduale-tex/10_St.Dominic.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_00_.combined.test.north-guilford-alphabetical.tex
+++ b/graduale-tex/1_00_.combined.test.north-guilford-alphabetical.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_00_.combined.test.north-guilford.tex
+++ b/graduale-tex/1_00_.combined.test.north-guilford.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_00_.combined.test.north-guilford_interim.tex
+++ b/graduale-tex/1_00_.combined.test.north-guilford_interim.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_00_Asperges.tex
+++ b/graduale-tex/1_00_Asperges.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_00_Common.of.Saints-North-Guilford-virgin-martyr.tex
+++ b/graduale-tex/1_00_Common.of.Saints-North-Guilford-virgin-martyr.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_00_Common.of.Saints-North-Guilford.tex
+++ b/graduale-tex/1_00_Common.of.Saints-North-Guilford.tex
@@ -68,7 +68,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_00_Reception_of_a_bishop.tex
+++ b/graduale-tex/1_00_Reception_of_a_bishop.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_02_Sunday.in.Ordinary.Time--english.tex
+++ b/graduale-tex/1_02_Sunday.in.Ordinary.Time--english.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_03_Sunday.in.Ordinary.Time--english.tex
+++ b/graduale-tex/1_03_Sunday.in.Ordinary.Time--english.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_04_Sunday.in.Ordinary.Time--english.tex
+++ b/graduale-tex/1_04_Sunday.in.Ordinary.Time--english.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_08_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_08_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_09_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_09_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_10_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_10_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_11_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_11_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_12_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_12_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_13_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_13_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_14_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_14_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_15_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_15_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_16_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_16_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_17_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_17_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_18_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_18_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_19_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_19_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_20_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_20_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_21_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_21_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_22_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_22_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_23_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_23_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_24_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_24_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_25_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_25_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_26_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_26_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_27_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_27_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_28_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_28_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_29_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_29_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_30_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_30_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_31_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_31_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_32_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_32_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_33_Sunday.in.Ordinary.Time--SVF.tex
+++ b/graduale-tex/1_33_Sunday.in.Ordinary.Time--SVF.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_33_Sunday.in.Ordinary.Time.tex
+++ b/graduale-tex/1_33_Sunday.in.Ordinary.Time.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_C_01_Common.of.Dedication.tex
+++ b/graduale-tex/1_C_01_Common.of.Dedication.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_C_02_Common.of.BVM.tex
+++ b/graduale-tex/1_C_02_Common.of.BVM.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_O_Credo_OP.tex
+++ b/graduale-tex/1_O_Credo_OP.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_Requiem.tex
+++ b/graduale-tex/1_Requiem.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_Rituales_4--Pro_sponsis-en.tex
+++ b/graduale-tex/1_Rituales_4--Pro_sponsis-en.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_Rituales_4--Pro_sponsis.tex
+++ b/graduale-tex/1_Rituales_4--Pro_sponsis.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_SD_Christ_the_King.tex
+++ b/graduale-tex/1_SD_Christ_the_King.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_SD_Corpus_Christi--of_et_dr.tex
+++ b/graduale-tex/1_SD_Corpus_Christi--of_et_dr.tex
@@ -68,7 +68,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_SD_Corpus_Christi_Dominican_Rite.tex
+++ b/graduale-tex/1_SD_Corpus_Christi_Dominican_Rite.tex
@@ -68,7 +68,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_SD_Corpus_Christi_Ordinary_Form.tex
+++ b/graduale-tex/1_SD_Corpus_Christi_Ordinary_Form.tex
@@ -68,7 +68,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_SD_Sacred_Heart.tex
+++ b/graduale-tex/1_SD_Sacred_Heart.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_SD_Trinity.tex
+++ b/graduale-tex/1_SD_Trinity.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_01.28--st.thomas_aquinas-svf.tex
+++ b/graduale-tex/1_S_01.28--st.thomas_aquinas-svf.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_01.28--st.thomas_aquinas.tex
+++ b/graduale-tex/1_S_01.28--st.thomas_aquinas.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_02.02--presentation_of_the_lord.tex
+++ b/graduale-tex/1_S_02.02--presentation_of_the_lord.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_03.17--st.patrick.tex
+++ b/graduale-tex/1_S_03.17--st.patrick.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_03.19--st.joseph.tex
+++ b/graduale-tex/1_S_03.19--st.joseph.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_03.25--annunciation.tex
+++ b/graduale-tex/1_S_03.25--annunciation.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_04.05--st_vincent.tex
+++ b/graduale-tex/1_S_04.05--st_vincent.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_04.29--st_catherine_of_siena.tex
+++ b/graduale-tex/1_S_04.29--st_catherine_of_siena.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_08.08--st_dominic-sequence-only.tex
+++ b/graduale-tex/1_S_08.08--st_dominic-sequence-only.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_08.08--st_dominic.tex
+++ b/graduale-tex/1_S_08.08--st_dominic.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_09.08--nativitas_bvm.tex
+++ b/graduale-tex/1_S_09.08--nativitas_bvm.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_09.14--exaltation_of_the_holy_cross.tex
+++ b/graduale-tex/1_S_09.14--exaltation_of_the_holy_cross.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_10.07--our_lady_of_the_rosary.tex
+++ b/graduale-tex/1_S_10.07--our_lady_of_the_rosary.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_11.01--omnium_sanctorum.tex
+++ b/graduale-tex/1_S_11.01--omnium_sanctorum.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_11.02--in_commemoratione_omnium_fidelium_defunctorum--english.tex
+++ b/graduale-tex/1_S_11.02--in_commemoratione_omnium_fidelium_defunctorum--english.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_11.02--in_commemoratione_omnium_fidelium_defunctorum--libera_me.tex
+++ b/graduale-tex/1_S_11.02--in_commemoratione_omnium_fidelium_defunctorum--libera_me.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_11.02--in_commemoratione_omnium_fidelium_defunctorum.tex
+++ b/graduale-tex/1_S_11.02--in_commemoratione_omnium_fidelium_defunctorum.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_11.15--st_albert_the_great-svf.tex
+++ b/graduale-tex/1_S_11.15--st_albert_the_great-svf.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_11.15--st_albert_the_great.tex
+++ b/graduale-tex/1_S_11.15--st_albert_the_great.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_11.21--presentation_of_the_bvm.tex
+++ b/graduale-tex/1_S_11.21--presentation_of_the_bvm.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_12.08--immaculate_conception.tex
+++ b/graduale-tex/1_S_12.08--immaculate_conception.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_S_12.28--holy_innocents.tex
+++ b/graduale-tex/1_S_12.28--holy_innocents.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.1_Advent1.tex
+++ b/graduale-tex/1_T.1_Advent1.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.1_Advent2.tex
+++ b/graduale-tex/1_T.1_Advent2.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.1_Advent3.tex
+++ b/graduale-tex/1_T.1_Advent3.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.1_Advent4.tex
+++ b/graduale-tex/1_T.1_Advent4.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.2_Christmas_1_Vigil_Mass.tex
+++ b/graduale-tex/1_T.2_Christmas_1_Vigil_Mass.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.2_Christmas_2_Mass_during_the_Night--SVF.tex
+++ b/graduale-tex/1_T.2_Christmas_2_Mass_during_the_Night--SVF.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.2_Christmas_2_Mass_during_the_Night.tex
+++ b/graduale-tex/1_T.2_Christmas_2_Mass_during_the_Night.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.2_Christmas_3_Mass_at_Dawn.tex
+++ b/graduale-tex/1_T.2_Christmas_3_Mass_at_Dawn.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.2_Christmas_4_Mass_during_the_Day.tex
+++ b/graduale-tex/1_T.2_Christmas_4_Mass_during_the_Day.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.3_Holy_Family.tex
+++ b/graduale-tex/1_T.3_Holy_Family.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.3_Holy_Family_DR.tex
+++ b/graduale-tex/1_T.3_Holy_Family_DR.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.3_Mary_Mother_of_God_Jan_1.tex
+++ b/graduale-tex/1_T.3_Mary_Mother_of_God_Jan_1.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.4.1_Baptism_of_the_Lord.tex
+++ b/graduale-tex/1_T.4.1_Baptism_of_the_Lord.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.5.0.Ash_Wednesday.tex
+++ b/graduale-tex/1_T.5.0.Ash_Wednesday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.5.3.Lent3.tex
+++ b/graduale-tex/1_T.5.3.Lent3.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.5.4.Lent4.tex
+++ b/graduale-tex/1_T.5.4.Lent4.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.5.5.Lent5.tex
+++ b/graduale-tex/1_T.5.5.Lent5.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.5.5.Lent5e.Feria_VI_Post_Dominicam_Passionis_DR.tex
+++ b/graduale-tex/1_T.5.5.Lent5e.Feria_VI_Post_Dominicam_Passionis_DR.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.6.1.Palm_Sunday.tex
+++ b/graduale-tex/1_T.6.1.Palm_Sunday.tex
@@ -67,7 +67,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.6.5.Holy_Thursday--foot-washing.tex
+++ b/graduale-tex/1_T.6.5.Holy_Thursday--foot-washing.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.6.5.Holy_Thursday.tex
+++ b/graduale-tex/1_T.6.5.Holy_Thursday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.6.6.Good_Friday.tex
+++ b/graduale-tex/1_T.6.6.Good_Friday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.0.Easter_Vigil-2023.tex
+++ b/graduale-tex/1_T.7.0.Easter_Vigil-2023.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.0.Easter_Vigil.tex
+++ b/graduale-tex/1_T.7.0.Easter_Vigil.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.1.Easter_Sunday.tex
+++ b/graduale-tex/1_T.7.1.Easter_Sunday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.2.Second_Sunday_of_Easter.tex
+++ b/graduale-tex/1_T.7.2.Second_Sunday_of_Easter.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.3.Third_Sunday_of_Easter.tex
+++ b/graduale-tex/1_T.7.3.Third_Sunday_of_Easter.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.4.Fourth_Sunday_of_Easter.tex
+++ b/graduale-tex/1_T.7.4.Fourth_Sunday_of_Easter.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.5.Fifth_Sunday_of_Easter.tex
+++ b/graduale-tex/1_T.7.5.Fifth_Sunday_of_Easter.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.6.Sixth_Sunday_of_Easter.tex
+++ b/graduale-tex/1_T.7.6.Sixth_Sunday_of_Easter.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.6d.Vigil_of_the_Ascension.tex
+++ b/graduale-tex/1_T.7.6d.Vigil_of_the_Ascension.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.6e.Ascension.tex
+++ b/graduale-tex/1_T.7.6e.Ascension.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.7.Seventh_Sunday_of_Easter.tex
+++ b/graduale-tex/1_T.7.7.Seventh_Sunday_of_Easter.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.8.1.Vigil_of_Pentecost.tex
+++ b/graduale-tex/1_T.7.8.1.Vigil_of_Pentecost.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_T.7.8.2.Pentecost.tex
+++ b/graduale-tex/1_T.7.8.2.Pentecost.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/1_test.tex
+++ b/graduale-tex/1_test.tex
@@ -68,7 +68,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/parish-study.tex
+++ b/graduale-tex/parish-study.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/passion_all_four.tex
+++ b/graduale-tex/passion_all_four.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/passion_john-harmony.tex
+++ b/graduale-tex/passion_john-harmony.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/passion_john.tex
+++ b/graduale-tex/passion_john.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/passion_luke.tex
+++ b/graduale-tex/passion_luke.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/passion_mark.tex
+++ b/graduale-tex/passion_mark.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/graduale-tex/passion_matthew.tex
+++ b/graduale-tex/passion_matthew.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/0001_Psalm_Tones.tex
+++ b/office-tex/0001_Psalm_Tones.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/000_Triduum_Booklet.tex
+++ b/office-tex/000_Triduum_Booklet.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/000_Triduum_Booklet_01_Holy_Thursday.tex
+++ b/office-tex/000_Triduum_Booklet_01_Holy_Thursday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/000_Triduum_Booklet_02_Good_Friday.tex
+++ b/office-tex/000_Triduum_Booklet_02_Good_Friday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/000_Triduum_Booklet_03_Holy_Saturday.tex
+++ b/office-tex/000_Triduum_Booklet_03_Holy_Saturday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.0.Intro_Hymns.tex
+++ b/office-tex/001_Compline.0.Intro_Hymns.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.000_complete-cover-test.tex
+++ b/office-tex/001_Compline.000_complete-cover-test.tex
@@ -90,7 +90,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.000_complete.tex
+++ b/office-tex/001_Compline.000_complete.tex
@@ -99,7 +99,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.1.psalms.tex
+++ b/office-tex/001_Compline.1.psalms.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.1a.psalms-test.tex
+++ b/office-tex/001_Compline.1a.psalms-test.tex
@@ -82,7 +82,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.1a.psalms-test2.tex
+++ b/office-tex/001_Compline.1a.psalms-test2.tex
@@ -82,7 +82,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.1b--hymns.tex
+++ b/office-tex/001_Compline.1b--hymns.tex
@@ -83,7 +83,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.1c--final--antiphons.tex
+++ b/office-tex/001_Compline.1c--final--antiphons.tex
@@ -83,7 +83,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.2.Rx.tex
+++ b/office-tex/001_Compline.2.Rx.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.3.Final.Antiphons.tex
+++ b/office-tex/001_Compline.3.Final.Antiphons.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/001_Compline.9.friday.tex
+++ b/office-tex/001_Compline.9.friday.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/002_Compline_Responsories_and_Gospel_Canticles.tex
+++ b/office-tex/002_Compline_Responsories_and_Gospel_Canticles.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/002_Triduum_Booklet.tex
+++ b/office-tex/002_Triduum_Booklet.tex
@@ -90,7 +90,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/00_Benedictus.tex
+++ b/office-tex/00_Benedictus.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_02_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_02_sunday_in_OT_Year_A.tex
@@ -71,7 +71,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_02_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_02_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_02_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_02_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_03_sunday_in_OT_Year_A_and_B.tex
+++ b/office-tex/02_03_sunday_in_OT_Year_A_and_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_03_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_03_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_04_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_04_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_04_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_04_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_04_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_04_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_05_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_05_sunday_in_OT_Year_A.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_05_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_05_sunday_in_OT_Year_B.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_05_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_05_sunday_in_OT_Year_C.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_06_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_06_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_06_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_06_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_06_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_06_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_07_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_07_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_07_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_07_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_07_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_07_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_08_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_08_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_08_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_08_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_08_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_08_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_09_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_09_sunday_in_OT_Year_B.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_09_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_09_sunday_in_OT_Year_C.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_10_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_10_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_11_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_11_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_11_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_11_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_11_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_11_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_12_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_12_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_12_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_12_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_12_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_12_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_13_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_13_sunday_in_OT_Year_A.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_13_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_13_sunday_in_OT_Year_B.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_13_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_13_sunday_in_OT_Year_C.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_14_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_14_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_14_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_14_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_14_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_14_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_15_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_15_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_15_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_15_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_15_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_15_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_16_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_16_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_16_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_16_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_16_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_16_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_17_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_17_sunday_in_OT_Year_A.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_17_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_17_sunday_in_OT_Year_B.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_17_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_17_sunday_in_OT_Year_C.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_18_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_18_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_18_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_18_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_18_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_18_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_19_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_19_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_19_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_19_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_19_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_19_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_20_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_20_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_20_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_20_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_20_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_20_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_21_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_21_sunday_in_OT_Year_A.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_21_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_21_sunday_in_OT_Year_B.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_21_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_21_sunday_in_OT_Year_C.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_22_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_22_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_22_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_22_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_22_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_22_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_23_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_23_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_23_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_23_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_23_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_23_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_24_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_24_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_24_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_24_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_24_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_24_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_25_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_25_sunday_in_OT_Year_A.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_25_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_25_sunday_in_OT_Year_B.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_25_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_25_sunday_in_OT_Year_C.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_26_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_26_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_26_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_26_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_26_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_26_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_27_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_27_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_27_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_27_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_27_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_27_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_28_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_28_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_28_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_28_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_28_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_28_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_29_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_29_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_29_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_29_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_29_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_29_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_30_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_30_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_30_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_30_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_30_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_30_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_31_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_31_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_31_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_31_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_31_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_31_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_32_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_32_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_32_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_32_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_32_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_32_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_33_sunday_in_OT_Year_A.tex
+++ b/office-tex/02_33_sunday_in_OT_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_33_sunday_in_OT_Year_B.tex
+++ b/office-tex/02_33_sunday_in_OT_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_33_sunday_in_OT_Year_C.tex
+++ b/office-tex/02_33_sunday_in_OT_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_SD-christ-the-king--First_Vespers.tex
+++ b/office-tex/02_SD-christ-the-king--First_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_SD-christ-the-king--Second_Vespers.tex
+++ b/office-tex/02_SD-christ-the-king--Second_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_SD-corpus-christi.tex
+++ b/office-tex/02_SD-corpus-christi.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_SD-holy-trinity.tex
+++ b/office-tex/02_SD-holy-trinity.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent1_1st_Vespers_Years_A_B_C.tex
+++ b/office-tex/02_T.1_Advent1_1st_Vespers_Years_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent1_Year_A.tex
+++ b/office-tex/02_T.1_Advent1_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent1_Year_B.tex
+++ b/office-tex/02_T.1_Advent1_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent1_Year_C.tex
+++ b/office-tex/02_T.1_Advent1_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent2_Year_A_and_B.tex
+++ b/office-tex/02_T.1_Advent2_Year_A_and_B.tex
@@ -69,7 +69,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent2_Year_C.tex
+++ b/office-tex/02_T.1_Advent2_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent3_Dec_17.tex
+++ b/office-tex/02_T.1_Advent3_Dec_17.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent3_Year_A.tex
+++ b/office-tex/02_T.1_Advent3_Year_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent3_Year_B.tex
+++ b/office-tex/02_T.1_Advent3_Year_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent3_Year_C.tex
+++ b/office-tex/02_T.1_Advent3_Year_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent4_Dec_17.tex
+++ b/office-tex/02_T.1_Advent4_Dec_17.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent4_Dec_18.tex
+++ b/office-tex/02_T.1_Advent4_Dec_18.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent4_Dec_19.tex
+++ b/office-tex/02_T.1_Advent4_Dec_19.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent4_Dec_20.tex
+++ b/office-tex/02_T.1_Advent4_Dec_20.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent4_Dec_21.tex
+++ b/office-tex/02_T.1_Advent4_Dec_21.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent4_Dec_22.tex
+++ b/office-tex/02_T.1_Advent4_Dec_22.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.1_Advent4_Dec_23.tex
+++ b/office-tex/02_T.1_Advent4_Dec_23.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.2.1_Holy_Family_Second_Vespers.tex
+++ b/office-tex/02_T.2.1_Holy_Family_Second_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.2_Christmas_Second_Vespers.tex
+++ b/office-tex/02_T.2_Christmas_Second_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.3_Mary_Mother_of_God_Jan_1_1st_Vespers.tex
+++ b/office-tex/02_T.3_Mary_Mother_of_God_Jan_1_1st_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.3_Mary_Mother_of_God_Jan_1_2nd_Vespers.tex
+++ b/office-tex/02_T.3_Mary_Mother_of_God_Jan_1_2nd_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.4.1_Baptism_of_the_Lord.tex
+++ b/office-tex/02_T.4.1_Baptism_of_the_Lord.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.4_Epiphany_2nd_Vespers.tex
+++ b/office-tex/02_T.4_Epiphany_2nd_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.1.First_Sunday_of_Lent_2nd_Vespers_A_B_C.tex
+++ b/office-tex/02_T.5.1.First_Sunday_of_Lent_2nd_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.2.Second_Sunday_of_Lent_1st_Vespers_A_B_C.tex
+++ b/office-tex/02_T.5.2.Second_Sunday_of_Lent_1st_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.2.Second_Sunday_of_Lent_2nd_Vespers_A_B_C.tex
+++ b/office-tex/02_T.5.2.Second_Sunday_of_Lent_2nd_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.3.Third_Sunday_of_Lent_2nd_Vespers_A.tex
+++ b/office-tex/02_T.5.3.Third_Sunday_of_Lent_2nd_Vespers_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.3.Third_Sunday_of_Lent_2nd_Vespers_B.tex
+++ b/office-tex/02_T.5.3.Third_Sunday_of_Lent_2nd_Vespers_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.3.Third_Sunday_of_Lent_2nd_Vespers_C.tex
+++ b/office-tex/02_T.5.3.Third_Sunday_of_Lent_2nd_Vespers_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.4.Fourth_Sunday_of_Lent_2nd_Vespers_A.tex
+++ b/office-tex/02_T.5.4.Fourth_Sunday_of_Lent_2nd_Vespers_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.4.Fourth_Sunday_of_Lent_2nd_Vespers_B.tex
+++ b/office-tex/02_T.5.4.Fourth_Sunday_of_Lent_2nd_Vespers_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.4.Fourth_Sunday_of_Lent_2nd_Vespers_C.tex
+++ b/office-tex/02_T.5.4.Fourth_Sunday_of_Lent_2nd_Vespers_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.5.Fifth_Sunday_of_Lent_2nd_Vespers_A.tex
+++ b/office-tex/02_T.5.5.Fifth_Sunday_of_Lent_2nd_Vespers_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.5.Fifth_Sunday_of_Lent_2nd_Vespers_B.tex
+++ b/office-tex/02_T.5.5.Fifth_Sunday_of_Lent_2nd_Vespers_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.5.5.Fifth_Sunday_of_Lent_2nd_Vespers_C.tex
+++ b/office-tex/02_T.5.5.Fifth_Sunday_of_Lent_2nd_Vespers_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.6.1.Palm.Sunday.2nd_Vespers_A_B_C.tex
+++ b/office-tex/02_T.6.1.Palm.Sunday.2nd_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.1.Easter_Sunday_2nd_Vespers_A_B_C--solemn_magnificat.tex
+++ b/office-tex/02_T.7.1.Easter_Sunday_2nd_Vespers_A_B_C--solemn_magnificat.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.1.Easter_Sunday_2nd_Vespers_A_B_C.tex
+++ b/office-tex/02_T.7.1.Easter_Sunday_2nd_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.2.Second_Sunday_of_Easter_2nd_Vespers_2018--hymn_alone.tex
+++ b/office-tex/02_T.7.2.Second_Sunday_of_Easter_2nd_Vespers_2018--hymn_alone.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.2.Second_Sunday_of_Easter_2nd_Vespers_2018.tex
+++ b/office-tex/02_T.7.2.Second_Sunday_of_Easter_2nd_Vespers_2018.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.2.Second_Sunday_of_Easter_2nd_Vespers_A_B_C.tex
+++ b/office-tex/02_T.7.2.Second_Sunday_of_Easter_2nd_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.3.Third_Sunday_of_Easter_2nd_Vespers_A.tex
+++ b/office-tex/02_T.7.3.Third_Sunday_of_Easter_2nd_Vespers_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.3.Third_Sunday_of_Easter_2nd_Vespers_B.tex
+++ b/office-tex/02_T.7.3.Third_Sunday_of_Easter_2nd_Vespers_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.3.Third_Sunday_of_Easter_2nd_Vespers_C.tex
+++ b/office-tex/02_T.7.3.Third_Sunday_of_Easter_2nd_Vespers_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.4.Fourth_Sunday_of_Easter_2nd_Vespers_A.tex
+++ b/office-tex/02_T.7.4.Fourth_Sunday_of_Easter_2nd_Vespers_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.4.Fourth_Sunday_of_Easter_2nd_Vespers_B.tex
+++ b/office-tex/02_T.7.4.Fourth_Sunday_of_Easter_2nd_Vespers_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.4.Fourth_Sunday_of_Easter_2nd_Vespers_C.tex
+++ b/office-tex/02_T.7.4.Fourth_Sunday_of_Easter_2nd_Vespers_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.5.Fifth_Sunday_of_Easter_2nd_Vespers_A.tex
+++ b/office-tex/02_T.7.5.Fifth_Sunday_of_Easter_2nd_Vespers_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.5.Fifth_Sunday_of_Easter_2nd_Vespers_B.tex
+++ b/office-tex/02_T.7.5.Fifth_Sunday_of_Easter_2nd_Vespers_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.5.Fifth_Sunday_of_Easter_2nd_Vespers_C.tex
+++ b/office-tex/02_T.7.5.Fifth_Sunday_of_Easter_2nd_Vespers_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.6.Sixth_Sunday_of_Easter_2nd_Vespers_A.tex
+++ b/office-tex/02_T.7.6.Sixth_Sunday_of_Easter_2nd_Vespers_A.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.6.Sixth_Sunday_of_Easter_2nd_Vespers_B.tex
+++ b/office-tex/02_T.7.6.Sixth_Sunday_of_Easter_2nd_Vespers_B.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.6.Sixth_Sunday_of_Easter_2nd_Vespers_C.tex
+++ b/office-tex/02_T.7.6.Sixth_Sunday_of_Easter_2nd_Vespers_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.7.Seventh_Sunday_of_Easter_2nd_Vespers_A_B_C.tex
+++ b/office-tex/02_T.7.7.Seventh_Sunday_of_Easter_2nd_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/02_T.7.8.Pentecost_Sunday_2nd_Vespers_A_B_C.tex
+++ b/office-tex/02_T.7.8.Pentecost_Sunday_2nd_Vespers_A_B_C.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/03_02.02-presentation_of_the_lord.tex
+++ b/office-tex/03_02.02-presentation_of_the_lord.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/03_03.17-st_patrick_1st_vespers.tex
+++ b/office-tex/03_03.17-st_patrick_1st_vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/03_06.24-nativity_of_st_john_the_baptist_2nd_Vespers.tex
+++ b/office-tex/03_06.24-nativity_of_st_john_the_baptist_2nd_Vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/03_08.06-transfiguration.tex
+++ b/office-tex/03_08.06-transfiguration.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/03_09.14-exaltation.tex
+++ b/office-tex/03_09.14-exaltation.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/03_Compline_3_Tuesday_Ferial.tex
+++ b/office-tex/03_Compline_3_Tuesday_Ferial.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/03_Compline_Antiphons_only.tex
+++ b/office-tex/03_Compline_Antiphons_only.tex
@@ -71,7 +71,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-%% \usepackage{ulem}
+%% \usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/04_Benedictus_Roman_8G.tex
+++ b/office-tex/04_Benedictus_Roman_8G.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/04_Lauds_misc_Irenaeus_week_4.tex
+++ b/office-tex/04_Lauds_misc_Irenaeus_week_4.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/04_Vespers_Sts_Peter_and_Paul_Dominican_Rite.tex
+++ b/office-tex/04_Vespers_Sts_Peter_and_Paul_Dominican_Rite.tex
@@ -71,7 +71,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/10_T.2.Christmas.office.of.readings.tex
+++ b/office-tex/10_T.2.Christmas.office.of.readings.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/10_T.6.Palm.Sunday.Terce.tex
+++ b/office-tex/10_T.6.Palm.Sunday.Terce.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/10_T.6.St.Joseph.Chants.tex
+++ b/office-tex/10_T.6.St.Joseph.Chants.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/11_Iustus_ut_palma_examples.tex
+++ b/office-tex/11_Iustus_ut_palma_examples.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/chants/hy-veni_creator.tex
+++ b/office-tex/chants/hy-veni_creator.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/cliop-vesperale/08.08--dominicus.tex
+++ b/office-tex/cliop-vesperale/08.08--dominicus.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/dominic-office/dominic_proper_chants-1vespers-matins.tex
+++ b/office-tex/dominic-office/dominic_proper_chants-1vespers-matins.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/dominic-office/dominic_proper_chants-lauds-midday-vespers.tex
+++ b/office-tex/dominic-office/dominic_proper_chants-lauds-midday-vespers.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/dominic-office/te_deum_op.tex
+++ b/office-tex/dominic-office/te_deum_op.tex
@@ -70,7 +70,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/misc_o_antiphons.tex
+++ b/office-tex/misc_o_antiphons.tex
@@ -71,7 +71,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/misc_office-of-the-dead-vespers.tex
+++ b/office-tex/misc_office-of-the-dead-vespers.tex
@@ -71,7 +71,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/misc_veni_creator.tex
+++ b/office-tex/misc_veni_creator.tex
@@ -71,7 +71,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,english]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum-wien/0triduum-alles.tex
+++ b/office-tex/triduum_projects/de-triduum-wien/0triduum-alles.tex
@@ -95,7 +95,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum-wien/1triduum-thursday.tex
+++ b/office-tex/triduum_projects/de-triduum-wien/1triduum-thursday.tex
@@ -67,7 +67,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-%%\usepackage{ulem}
+%%\usepackage[normalem]{ulem}
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum-wien/2triduum-friday.tex
+++ b/office-tex/triduum_projects/de-triduum-wien/2triduum-friday.tex
@@ -67,7 +67,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum-wien/3triduum-saturday.tex
+++ b/office-tex/triduum_projects/de-triduum-wien/3triduum-saturday.tex
@@ -67,7 +67,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-%%\usepackage{ulem} %%This was causing the italics to turn into underlines for some reason.
+%%\usepackage[normalem]{ulem} %%This was causing the italics to turn into underlines for some reason.
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum/0triduum-alles.tex
+++ b/office-tex/triduum_projects/de-triduum/0triduum-alles.tex
@@ -95,7 +95,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum/1triduum-thursday.tex
+++ b/office-tex/triduum_projects/de-triduum/1triduum-thursday.tex
@@ -67,7 +67,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum/2triduum-friday.tex
+++ b/office-tex/triduum_projects/de-triduum/2triduum-friday.tex
@@ -67,7 +67,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}

--- a/office-tex/triduum_projects/de-triduum/3triduum-saturday.tex
+++ b/office-tex/triduum_projects/de-triduum/3triduum-saturday.tex
@@ -67,7 +67,7 @@
 
 %% General settings (rev. January 19, 2015)
 
-\usepackage{ulem}
+\usepackage[normalem]{ulem}
 
 \usepackage[latin,german]{babel}
 \usepackage{lettrine}


### PR DESCRIPTION
The `ulem` package redefines `\emph` to use underlining. Passing the `normalem` option turns this behavior off, so `\emph` is italics.

Possibly 6d685c6 could be reverted.